### PR TITLE
Return Html.Events instead of using ports for onPointerMove and onPointerUp

### DIFF
--- a/examples/src/Introduction/Basic.elm
+++ b/examples/src/Introduction/Basic.elm
@@ -5,6 +5,7 @@ import DnDList
 import Home exposing (onPointerMove, onPointerUp, releasePointerCapture)
 import Html
 import Html.Attributes
+import Html.Events
 import Json.Encode
 
 
@@ -44,9 +45,14 @@ config =
     }
 
 
+noOpPort : (Json.Encode.Value -> msg) -> Sub msg
+noOpPort _ =
+    Sub.none
+
+
 system : DnDList.System Fruit Msg
 system =
-    DnDList.createWithTouch config MyMsg onPointerMove onPointerUp releasePointerCapture
+    DnDList.createWithTouch config MyMsg noOpPort noOpPort releasePointerCapture
 
 
 
@@ -110,6 +116,11 @@ view model =
     Html.section
         [ Html.Attributes.style "text-align" "center"
         , Html.Attributes.style "touch-action" "none"
+        , Html.Events.on "pointermove" system.onPointerMove
+        , Html.Events.on "pointerup" system.onPointerUp
+
+        -- pointer capture hack to continue "globally" the event anywhere on document.
+        -- , Html.Attributes.attribute "onpointerdown" "event.target.setPointerCapture(event.pointerId);"
         ]
         [ model.items
             |> List.indexedMap (itemView model.dnd)

--- a/src/DnDList.elm
+++ b/src/DnDList.elm
@@ -288,6 +288,8 @@ type alias System a msg =
     , dropEvents : DropIndex -> DropElementId -> List (Html.Attribute msg)
     , ghostStyles : Model -> List (Html.Attribute msg)
     , info : Model -> Maybe Info
+    , onPointerMove : Json.Decode.Decoder msg
+    , onPointerUp : Json.Decode.Decoder msg
     }
 
 
@@ -319,6 +321,10 @@ create config stepMsg =
     , dropEvents = dropEvents stepMsg
     , ghostStyles = ghostStyles config.movement
     , info = info
+
+    -- todo: these don't make sense without touch
+    , onPointerMove = onPointerMove2 stepMsg
+    , onPointerUp = onPointerUp2 stepMsg
     }
 
 
@@ -369,6 +375,8 @@ createWithTouch config stepMsg onPointerMove onPointerUp releasePointerCapture =
     , dropEvents = dropEventsWithTouch stepMsg
     , ghostStyles = ghostStyles config.movement
     , info = info
+    , onPointerMove = onPointerMove2 stepMsg
+    , onPointerUp = onPointerUp2 stepMsg
     }
 
 
@@ -585,6 +593,20 @@ subscriptions stepMsg (Model model) =
                 , Browser.Events.onMouseUp
                     (Json.Decode.succeed (stepMsg DragEnd))
                 ]
+
+
+onPointerMove2 : (Msg -> msg) -> Json.Decode.Decoder msg
+onPointerMove2 stepMsg =
+    Internal.Common.Utils.decodeCoordinates
+        |> Json.Decode.map Drag
+        -- |> Json.Decode.map (\v -> Debug.log "onPointerMove2" (stepMsg v))
+        |> Json.Decode.map stepMsg
+
+
+onPointerUp2 : (Msg -> msg) -> Json.Decode.Decoder msg
+onPointerUp2 stepMsg =
+    stepMsg DragEnd
+        |> Json.Decode.succeed
 
 
 subscriptionsWithTouch : (Msg -> msg) -> ((Json.Encode.Value -> msg) -> Sub msg) -> ((Json.Encode.Value -> msg) -> Sub msg) -> Model -> Sub msg


### PR DESCRIPTION
This PR returns Html.Events for onPointerDown and onPointerUp instead of requiring the caller to pass in ports.

This only happens for the Basics exercise at the moment, but if we are happy with it we would follow through with the change.

I think its a little bit easier to use, but there isn't that much in it. The difference between having to use 1 port and no ports is a lot, but the difference between 1 port and 3 ports is very little.

The performance is probably a bit better, as the onpointerdown code only fires when it is over the relevant / parent html element, as opposed to anywhere on the page. There are many more elm updates though, as these only used to fire during a drag event, but now they fire all the time when over the parent html element.

I'm not sure how / if it would affect tha auto scroll, as this isn't working at the moment anyway, and I don't know how it works, but maybe something to consider.

Let me know what you think @annaghi